### PR TITLE
BugFix: displacements using incorrect module

### DIFF
--- a/Operator/Displace.cs
+++ b/Operator/Displace.cs
@@ -99,8 +99,8 @@ namespace LibNoise.Unity.Operator
             System.Diagnostics.Debug.Assert(this.m_modules[2] != null);
             System.Diagnostics.Debug.Assert(this.m_modules[3] != null);
             double dx = x + this.m_modules[1].GetValue(x, y, z);
-            double dy = y + this.m_modules[1].GetValue(x, y, z);
-            double dz = z + this.m_modules[1].GetValue(x, y, z);
+            double dy = y + this.m_modules[2].GetValue(x, y, z);
+            double dz = z + this.m_modules[3].GetValue(x, y, z);
             return this.m_modules[0].GetValue(dx, dy, dz);
         }
 


### PR DESCRIPTION
Only m_module[1] was being used for displacing x, y and z, when it should have been x displaced by [1], y displaced by [2] and z displaced by [3].
