### PR TITLE
Fix incorrect validation of GenerateSpherical's north/south arguments

### DIFF
--- a/Noise2D.cs
+++ b/Noise2D.cs
@@ -414,7 +414,7 @@ namespace LibNoise
         /// <param name="east">The clip region to the east.</param>
         public void GenerateSpherical(double south, double north, double west, double east)
         {
-            if (east <= west || north <= south)
+            if (east <= west || south <= north)
             {
                 throw new ArgumentException("Invalid east/west or north/south combination");
             }


### PR DESCRIPTION
I think north should always be greater than south, not the other way around. After applying this fix it generates the spherical texture as expected.