### PR TITLE
RidgedMultifractal сlass is completed. Small bug fix

### DIFF
--- a/Generator/Billow.cs
+++ b/Generator/Billow.cs
@@ -56,6 +56,7 @@ namespace LibNoise.Generator
 
         /// <summary>
         /// Gets or sets the frequency of the first octave.
+        /// <para>Frequency represents the number of cycles per unit length that a generation module outputs.</para>
         /// </summary>
         public double Frequency
         {
@@ -65,6 +66,7 @@ namespace LibNoise.Generator
 
         /// <summary>
         /// Gets or sets the lacunarity of the billowy noise.
+        /// <para>A multiplier that determines how quickly the frequency increases for each successive octave</para>
         /// </summary>
         public double Lacunarity
         {
@@ -83,6 +85,7 @@ namespace LibNoise.Generator
 
         /// <summary>
         /// Gets or sets the number of octaves of the billowy noise.
+        /// <para>Adding more octaves increases the detail of the perlin noise, but with the drawback of increasing the calculation time.</para>
         /// </summary>
         public int OctaveCount
         {
@@ -92,6 +95,7 @@ namespace LibNoise.Generator
 
         /// <summary>
         /// Gets or sets the persistence of the billowy noise.
+        /// <para>A multiplier that determines how quickly the amplitudes diminish for each successive octave.</para>
         /// </summary>
         public double Persistence
         {
@@ -121,8 +125,9 @@ namespace LibNoise.Generator
         /// <returns>The resulting output value.</returns>
         public override double GetValue(double x, double y, double z)
         {
-            var value = 0.0;
-            var curp = 1.0;
+            var value       = 0.0;
+            var amplitude   = 1.0;
+
             x *= _frequency;
             y *= _frequency;
             z *= _frequency;
@@ -134,11 +139,11 @@ namespace LibNoise.Generator
                 var seed = (_seed + i) & 0xffffffff;
                 var signal = Utils.GradientCoherentNoise3D(nx, ny, nz, seed, _quality);
                 signal = 2.0 * Math.Abs(signal) - 1.0;
-                value += signal * curp;
+                value += signal * amplitude;
                 x *= _lacunarity;
                 y *= _lacunarity;
                 z *= _lacunarity;
-                curp *= _persistence;
+                amplitude *= _persistence;
             }
             return value + 0.5;
         }

--- a/Generator/Perlin.cs
+++ b/Generator/Perlin.cs
@@ -55,6 +55,7 @@ namespace LibNoise.Generator
 
         /// <summary>
         /// Gets or sets the frequency of the first octave.
+        /// <para>Frequency represents the number of cycles per unit length that a generation module outputs.</para>
         /// </summary>
         public double Frequency
         {
@@ -64,6 +65,7 @@ namespace LibNoise.Generator
 
         /// <summary>
         /// Gets or sets the lacunarity of the perlin noise.
+        /// <para>A multiplier that determines how quickly the frequency increases for each successive octave.</para>
         /// </summary>
         public double Lacunarity
         {
@@ -82,6 +84,8 @@ namespace LibNoise.Generator
 
         /// <summary>
         /// Gets or sets the number of octaves of the perlin noise.
+        /// <para>The number of octaves control the amount of detail of the perlin noise
+        /// Adding more octaves increases the detail of the perlin noise, but with the drawback of increasing the calculation time.</para>
         /// </summary>
         public int OctaveCount
         {
@@ -90,7 +94,8 @@ namespace LibNoise.Generator
         }
 
         /// <summary>
-        /// Gets or sets the persistence of the perlin noise.
+        /// Gets or sets the persistence of the perlin noise. 
+        /// <para>A multiplier that determines how quickly the amplitudes diminish for each successive octave.</para>
         /// </summary>
         public double Persistence
         {
@@ -120,8 +125,9 @@ namespace LibNoise.Generator
         /// <returns>The resulting output value.</returns>
         public override double GetValue(double x, double y, double z)
         {
-            var value = 0.0;
-            var cp = 1.0;
+            var value       = 0.0;
+            var amplitude   = 1.0;
+
             x *= _frequency;
             y *= _frequency;
             z *= _frequency;
@@ -132,11 +138,11 @@ namespace LibNoise.Generator
                 var nz = Utils.MakeInt32Range(z);
                 var seed = (_seed + i) & 0xffffffff;
                 var signal = Utils.GradientCoherentNoise3D(nx, ny, nz, seed, _quality);
-                value += signal * cp;
+                value += signal * amplitude;
                 x *= _lacunarity;
                 y *= _lacunarity;
                 z *= _lacunarity;
-                cp *= _persistence;
+                amplitude *= _persistence;
             }
             return value;
         }

--- a/Noise2D.cs
+++ b/Noise2D.cs
@@ -500,9 +500,9 @@ namespace LibNoise
                 for (var y = 0; y < _ucHeight; y++)
                 {
                     var xPos = (_ucData[Mathf.Max(0, x - _ucBorder), y] -
-                                _ucData[Mathf.Min(x + _ucBorder, _height + _ucBorder), y]) / 2;
+                                _ucData[Mathf.Min(x + _ucBorder, _width + _ucBorder), y]) / 2;
                     var yPos = (_ucData[x, Mathf.Max(0, y - _ucBorder)] -
-                                _ucData[x, Mathf.Min(y + _ucBorder, _width + _ucBorder)]) / 2;
+                                _ucData[x, Mathf.Min(y + _ucBorder, _height + _ucBorder)]) / 2;
                     var normalX = new Vector3(xPos * intensity, 0, 1);
                     var normalY = new Vector3(0, yPos * intensity, 1);
                     // Get normal vector


### PR DESCRIPTION

For Ridged Multifractal noise following properties and descriptions have been added:
-SpectralWeightsExponent
-Gain
-Offset


Expanded description of the properties due to the original SharpNoise and LibNoise libraries for three modules:
 - Billow
 - Perlin
 - Ridged

Changes to the GetValue method: "double cp" value renamed to meaningful "double amplitude"