### PR TITLE
CRITICAL FIX: isSeamless in CreatePlanar was used incorrectly!

### DIFF
--- a/Noise2D.cs
+++ b/Noise2D.cs
@@ -310,7 +310,7 @@ namespace LibNoise
                 for (var y = 0; y < _ucHeight; y++)
                 {
                     float fv;
-                    if (isSeamless)
+                    if (!isSeamless)
                     {
                         fv = (float) GeneratePlanar(xc, zc);
                     }


### PR DESCRIPTION
There was a ! missing in the code, resulting in seamless textures when you didn't want them and the other way around.